### PR TITLE
Chore/add find payment config scope

### DIFF
--- a/lib/bb_payments/configuration.rb
+++ b/lib/bb_payments/configuration.rb
@@ -160,7 +160,7 @@ module BancoBrasilPayments
       @force_ending_format = false
       @logger = defined?(Jets) ? Jets.logger : Logger.new(STDOUT)
       @access_token_scopes = 'payments.transfers-info payments.transfer-batch-request '\
-                             'pagamentos-lote.lotes-requisicao pagamentos-lote.lotes-info '\
+                             'pagamentos-lote.lotes-requisicao pagamentos-lote.lotes-info pagamentos-lote.pagamentos-info '\
                              'pagamentos-lote.transferencias-pix-info pagamentos-lote.transferencias-pix-requisicao '\
                              'pagamentos-lote.cancelar-requisicao pagamentos-lote.transferencias-requisicao'
 

--- a/lib/bb_payments/version.rb
+++ b/lib/bb_payments/version.rb
@@ -1,3 +1,3 @@
 module BancoBrasilPayments
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
Para os serviços serem consumidos, é necessário que se coloque seu scope no access scope na config das requests... então adicionei o scope da rota transferencias/{id} encontrado em: https://publicador.developers.bb.com.br/bucket/api_Pagamentos_Lote_7ed02b1198.json
