### PR TITLE
fix(Auth): valid_token? method verify if token is older than expire_time

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    bb_payments (0.1.7)
+    bb_payments (0.2.0)
       bb_oauth (~> 1.0)
       json (~> 2.6, >= 2.1.0)
-      typhoeus (~> 1.0, >= 1.0.1)
+      typhoeus (~> 1.4, >= 1.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/bb_payments/api_client.rb
+++ b/lib/bb_payments/api_client.rb
@@ -307,7 +307,7 @@ module BancoBrasilPayments
 
     def valid_token?
       access_token_requested_at &&
-        (Time.zone.now - access_token_requested_at) > TOKEN_EXPIRE_TIME
+        (Time.zone.now - access_token_requested_at) < TOKEN_EXPIRE_TIME
     end
 
     def renew_token

--- a/lib/bb_payments/version.rb
+++ b/lib/bb_payments/version.rb
@@ -1,3 +1,3 @@
 module BancoBrasilPayments
-  VERSION = '0.1.9'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
aparentemente a função estava invertida, o que faz com que a maioria das requests fiquem gerando novos tokens
e quando o intervalo entre as requests é maior que o tempo de expiração, receberia erro 401